### PR TITLE
pulled color values for test trends result graphic from code into pro…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ THE SOFTWARE.
   </parent>
   <artifactId>greenballs</artifactId>
   <packaging>hpi</packaging>
-  <version>1.15-SNAPSHOT</version>
+  <version>1.16-SNAPSHOT</version>
   <name>Green Balls</name>
   <description>Because green balls are better than blue</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Green+Balls</url>

--- a/src/main/java/hudson/plugins/greenballs/ChartColorLoader.java
+++ b/src/main/java/hudson/plugins/greenballs/ChartColorLoader.java
@@ -1,0 +1,53 @@
+package hudson.plugins.greenballs;
+
+import java.awt.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public class ChartColorLoader {
+  final Logger logger = Logger.getLogger("hudson.plugins.greenballs");
+
+  public Color loadColorFromProperties() {
+    // preset the result --> if the config file is not found, the standard color will be returned
+    Color result = new Color(172, 218, 0);
+
+    try {
+      // get jenkins_home
+      String jenkinsHome = System.getenv("JENKINS_HOME");
+      // if the last slash is missing, add it
+      if (!jenkinsHome.endsWith("/")) {
+        jenkinsHome += "/";
+      }
+
+      // load the properties file
+      File file = new File(jenkinsHome + "plugins/greenballs/greenballs.properties");
+      logger.severe("path: " + file.getAbsolutePath());
+      FileInputStream fileInput = new FileInputStream(file);
+      Properties props = new Properties();
+      props.load(fileInput);
+      fileInput.close();
+
+      // resolve the color
+      String rgbProperty = props.getProperty("chart_rgb");
+      result = resolveColorFromProperty(rgbProperty);
+    } catch (IOException e) {
+      logger.warning("\"greenballs.properties\" file was not found. Chart color will be defaulted.");
+    } catch (NumberFormatException ex) {
+      logger.severe("Property \"chart-rgb\" could not be parsed to an Integer. " +
+                        "Make sure only full numbers splitted by commas are used.");
+    }
+
+    return result;
+  }
+
+  private Color resolveColorFromProperty(String rgbString) throws NumberFormatException{
+    String[] split = rgbString.split(",");
+    Integer r = Integer.parseInt(split[0]);
+    Integer g = Integer.parseInt(split[1]);
+    Integer b = Integer.parseInt(split[2]);
+    return new Color(r, g, b);
+  }
+}

--- a/src/main/java/hudson/plugins/greenballs/PluginImpl.java
+++ b/src/main/java/hudson/plugins/greenballs/PluginImpl.java
@@ -4,19 +4,17 @@ import hudson.Plugin;
 import hudson.PluginWrapper;
 import hudson.util.ColorPalette;
 import hudson.util.PluginServletFilter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
-import java.awt.Color;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+import java.awt.*;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
-
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
 
 /**
  * Entry point of a plugin.
@@ -47,9 +45,10 @@ public class PluginImpl extends Plugin {
       logger.log(Level.WARNING, "Unable to access plugin wrapper", e);
     }
     try {
+      ChartColorLoader colorLoader = new ChartColorLoader();
       Field colorValue = Color.class.getDeclaredField("value");
       colorValue.setAccessible(true);
-      colorValue.setInt(ColorPalette.BLUE, new Color(172, 218, 0).getRGB());
+      colorValue.setInt(ColorPalette.BLUE, colorLoader.loadColorFromProperties().getRGB());
     } catch (Exception e) {
       logger.log(Level.WARNING, "Unable to change BLUE ColorPalette", e);
     }

--- a/src/main/resources/greenballs.properties
+++ b/src/main/resources/greenballs.properties
@@ -1,0 +1,2 @@
+# chart_rgb sets the color of the successful test in the test trends graphic
+chart_rgb=0,0,0


### PR DESCRIPTION
we didnt like the green in the test results trend, so we pulled the color-definition of the graphic into a properties file (if that one is not found or something else fails, the color defaults to the value set before this pull-request)

commit message:
pulled color values for test trends result graphic from code into properties file (greenballs.properties)
this file must be under $JENKINS_HOME/plugins/greenballs
if it fails, the will default to the green defined beforehand
increased the pom snapshot version
